### PR TITLE
Allow falsey parameters to be passed to the api

### DIFF
--- a/library/ns1_record
+++ b/library/ns1_record
@@ -276,7 +276,7 @@ def update(zone, record, module):
     args = {}
     for i in RECORD_KEYS:
         if (
-            module.params.get(i) and
+            module.params.get(i) != None and
                 (
                     not cleaned_data or
                     i not in cleaned_data or

--- a/test.yml
+++ b/test.yml
@@ -138,6 +138,26 @@
       - debug: var=return
         when: debug is defined
 
+      - name: remove filters record test
+        local_action:
+          module: ns1_record
+          apiKey: "{{ key }}"
+          name: www
+          zone: "{{ test_zone }}"
+          state: present
+          type: A
+          answers:
+            - answer:
+                - 192.168.1.0
+              meta:
+                up: True
+          filters: []
+          ttl: 3600
+        register: return
+
+      - debug: var=return
+        when: debug is defined
+
       - name: test record delete with existing zone
         local_action:
           module: ns1_record


### PR DESCRIPTION
When setting a falsey parameter (Such as '{}' or '[]') to this module
the parameter gets effectively ignored due to its falsey nature. This
means that you cannot remove parameters such as 'filters' from a record
using this module (I.E. you cannot set filters to '[]' once it has been
set to anything else). I believe the intended behavior here is to not
modify parameters that are not set (Thus the != None). You you may omit
a parameter and retain the present functionality.

This may or may not be a desired change for this module overall, but it
was necessary for our use.