### PR TITLE
Update clean to preserve dict during iteration

### DIFF
--- a/library/ns1_record
+++ b/library/ns1_record
@@ -223,15 +223,15 @@ def api_params(module):
 
 def clean(d):
     if isinstance(d, dict):
+        if 'id' in d:
+            del d['id']
         for key,val in d.items():
             if isinstance(val, dict) or isinstance(val, list):
-                val = clean(val)
-            if key == 'id':
-                del d[key]
+                clean(val)
     if isinstance(d, list):
         for i in d:
             if isinstance(i, dict) or isinstance(i, list):
-                i = clean(i)
+                clean(i)
     return d
 
 


### PR DESCRIPTION
Fixes the following (seen running on python 3):

```
Traceback (most recent call last):
  File "/var/folders/f8/23xp00654plcv2b2tcc028680000gn/T/ansible_ck7g4isk/ansible_module_ns1_record.py", line 389, in <module>
    main()
  File "/var/folders/f8/23xp00654plcv2b2tcc028680000gn/T/ansible_ck7g4isk/ansible_module_ns1_record.py", line 359, in main
    update(zone, record, module)
  File "/var/folders/f8/23xp00654plcv2b2tcc028680000gn/T/ansible_ck7g4isk/ansible_module_ns1_record.py", line 274, in update
    cleaned_data = clean(record.data)
  File "/var/folders/f8/23xp00654plcv2b2tcc028680000gn/T/ansible_ck7g4isk/ansible_module_ns1_record.py", line 228, in clean
    val = clean(val)
  File "/var/folders/f8/23xp00654plcv2b2tcc028680000gn/T/ansible_ck7g4isk/ansible_module_ns1_record.py", line 234, in clean
    i = clean(i)
  File "/var/folders/f8/23xp00654plcv2b2tcc028680000gn/T/ansible_ck7g4isk/ansible_module_ns1_record.py", line 226, in clean
    for key,val in d.items():
RuntimeError: dictionary changed size during iteration
```