### PR TITLE
fix RuntimeError: dictionary changed size during iteration

### DIFF
--- a/library/ns1_record
+++ b/library/ns1_record
@@ -223,7 +223,7 @@ def api_params(module):
 
 def clean(d):
     if isinstance(d, dict):
-        for key,val in d.items():
+        for key,val in list(d.items()):
             if isinstance(val, dict) or isinstance(val, list):
                 val = clean(val)
             if key == 'id':


### PR DESCRIPTION
In Python 3.7 deleting a key from a dict produces a RuntimeError. Converting the items to a list fixes this.