### PR TITLE
Backports ns1_record module and tests submited to ansible-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ns1-ansible-modules
 ====================
 
-This role is the home for all NS1 specific modules.
+This libraray is the home for all NS1 specific modules.  It will serve as a preview for the modules submitted to ansible-core.
 
 Project Overview
 ================
@@ -21,30 +21,32 @@ Still Needed:
 Installation
 ============
 
-Install this from ansible-galaxy. `ansible-galaxy install cruisibesares.ns1`. You will need the ns1 python client version 0.9.2 or greater. This can be installed by running: `pip install nsone`. Additional information can be found here [nsone-python](https://github.com/nsone/nsone-python)
+Install this from ansible-galaxy. `ansible-galaxy install ns1.ns1`. You will need the ns1 python client version 0.9.19 or greater. This can be installed by running: `pip install nsone`. Additional information can be found here [ns1-python](https://github.com/ns1/ns1-python)
 
 Testing
 =======
 
 This module is tested by using ansible directly. 
 
+```
 	git clone https://github.com/ns1/ns1-ansible-modules.git
 	cd ns1-ansible-module
-	ansible -i local, test.yml --extra-vars key=<your ns1 api key> --extra-vars debug=yes --extra-vars test_zone=<a zone you have at ns1>
+	ansible-playbook -i local, tests/<name of module to test>.yaml --extra-vars ns1_token=<your NS1 API key> --extra-vars debug=yes --extra-vars test_zone=<a zone you have at ns1>
+```
 
 The debug flag is optional. You can use any test zone to get started, the only requirement is that it's not yet defined on the NS1 platform. That is, you do not need to make the zone authoritative through your registrar for the ansible module to work correctly.
 
-The current version of the module has been tested with ansible 1.9.2 and python 2.7.10.
+The current version of the module has been tested with Ansible 2.8.2 and python 3.7.2.
 
 Examples
 ========
 
-Check out test.yml which is all working ansible code. All of the resources try to model the [api](https://ns1.com/api/) objects as closely as possible. We will be adding the standard ansible documentation to the modules themselves shortly.
+Check out the integration tests in `tests/`, which is all working ansible code. All of the resources try to model the [api](https://ns1.com/api/) objects as closely as possible. 
 
 Contributing
 ============
 
-Contributions, ideas and criticisms are all welcome. Please keep the ansible test.yml up to date if you do wind up hacking on the project.
+Contributions, ideas and criticisms are all welcome. Please keep the integration tests up to date or add new ones if you do wind up hacking on the project.
 
 Notes:
 =====

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+
+library = ./library
+module_utils   = ./module_utils
+

--- a/library/ns1_record
+++ b/library/ns1_record
@@ -1,195 +1,276 @@
 #!/usr/bin/python
-#
-# (c) 2015, Che Ruisi-Besares <cruisibesares@ns1.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-DOCUMENTATION = """
+# Copyright: (c) 2019, Matthew Burtless <mburtless@ns1.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+from ansible.module_utils.basic import AnsibleModule
+
+try: 
+    from ansible.module_utils.basic import missing_required_lib 
+except Exception: 
+    def missing_required_lib(msg, reason=None, url=None):
+        return msg
+
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+
+DOCUMENTATION = '''
+---
 module: ns1_record
-short_description: "Add, modify & delete ns1 hosted DNS records."
+
+short_description: Create, modify and delete NS1 hosted DNS records.
+
+version_added: "2.9"
+
 description:
- - This module is a light wrapper around the ns1 api that allows for the
-   creation, modification, and deletion of ns1 record objects.
- - Additional record attributes can be passed to the module as documented below.
- - "See http://ns1.com for more details."
-requirements:
-  - "python >= 2.6"
-  - nsone >= 0.9.2
-version_added: "1.9.2"
-author: "Che Ruisi-Besares"
+  - Create, modify and delete record objects within an existing zone.
+
 options:
-    state:
+  state:
+    description:
+      - Whether the record should be present or not.  Use C(present) to create
+        or update and C(absent) to delete.
+    default: present
+    choices:
+      - absent
+      - present
+  name:
+    description:
+      - The subdomain of the record. For apex records, this should match the
+        value of I(zone).
+    required: true
+  zone:
+    description:
+      - Name of the existing DNS zone in which to manage the record.
+    required: true
+  answers:
+    description:
+      - An array of answers for this record (order matters). This can take
+        many forms depending on record type and desired effect. See
+        U(https://ns1.com/api) for more details.
+    required: true
+    suboptions:
+      answer:
         description:
-          - create or destroy the record, defaults to present. There is no
-            difference between present and active or absent and deleted.
-        required: true
-        choices: ['present', 'active', 'absent', 'deleted']
-    apiKey:
-        description:
-          - Unique client api key that can be created via the ns1 portal.
-        required: true
-    name:
-        description:
-          - The subdomain of the record. www for example.
-        required: true
-    zone:
-        description:
-          - the zone domain name for example example.com
-        required: true
-    answers:
-        description:
-          - This is the ns1 answer object for this record. This can take
-            Many forms depending on record type and desired effect. See
-            https://ns1.com/api/ for more details. As a note you can pass
-            an array or hash object via yml and it will passed directly to the
-            api.
-        required: true
-    ignore_missing_zone:
-        description:
-          - If you try to delete a record from a zone that has already been
-            deleted it will error. There are situations in which the user might
-            not care if the zone isn't there and just wants to ensure the record
-            is missing. In this case you can set this flag to True. This module
-            will then count any record that doesn't have a zone as absent.
+          - An array of RDATA values for this answer
+        type: list
         required: false
-        default: False
-    type:
+      meta:
         description:
-          - This is the record type of the record.
-        required: True
-        choices:
-          - A
-          - AAAA
-          - ALIAS
-          - AFSDB
-          - CNAME
-          - DNAME
-          - HINFO
-          - MX
-          - NAPT
-          - NS
-          - PTR
-          - RP
-          - SPF
-          - SRV
-          - TXT
-    use_client_subnet:
-        description:
-          - direct pass through of the use_client_subnet record flag.
+          - Answer level metadata
+        type: dict
         required: false
-        default: None
-    meta:
+  ignore_missing_zone:
+    description:
+      - Attempting to delete a record from a zone that is not present will
+        normally result in an error. This error can be ignored by setting this
+        flag to C(True). This module will then count any record without a valid
+        zone as absent.  This is useful for ensuring a record is absent,
+        regardless of the status of its zone.
+    required: false
+    default: false
+  record_mode:
+    description:
+      - Whether existing I(answers) or I(filters) values unspecified in the module
+        should be purged
+    default: purge
+    choices:
+      - append
+      - purge
+  type:
+    description:
+      - The type of the record to create, modify or delete.
+    required: true
+    choices:
+      - A
+      - AAAA
+      - ALIAS
+      - AFSDB
+      - CNAME
+      - DNAME
+      - HINFO
+      - MX
+      - NAPTR
+      - NS
+      - PTR
+      - RP
+      - SPF
+      - SRV
+      - TXT
+  use_client_subnet:
+    description:
+      - Whether record should be EDNS-Client-Subnet enabled
+    required: false
+  meta:
+    description:
+      - Record level metadata.
+    required: false
+  link:
+    description:
+      - The target of a linked record.
+    required: false
+  filters:
+    description:
+      - An array of filters for the record, for use in configuring dynamic
+        records (order matters)
+    required: false
+    suboptions:
+      filter:
         description:
-          - Record level meta data.
+          - The type of filter.
         required: false
-        default: None
-    link:
+      config:
         description:
-          - Creates a linked record.
+          - The filters' configuration
+        type: dict
         required: false
-        default: None
-    filters:
-        description:
-          - The filters object for the record. This has many forms depending on
-            the desired effect. Please read the notes section of the readme
-            accepted forms.
-        required: false
-        default: None
-    ttl:
-        description:
-          - ttl of the record.
-        required: false
-        default: 3600
-    regions:
-        description:
-          - The regions object for the record set.
-        required: false
-        default: None
-"""
+  ttl:
+    description:
+      - The TTL of the record.
+    required: false
+    default: 3600
+  regions:
+    description:
+      - The regions object for the record set.
+    required: false
+  apiKey:
+    description:
+      - Unique client api key that can be created via the NS1 portal.
+    required: true
 
-EXAMPLES = '''
-   - name: record creation
-        local_action:
-          module: ns1_record
-          apiKey: "{{ key }}"
-          name: www
-          zone: "{{ test_zone }}"
-          state: present
-          type: A
-          answers:
-            - answer:
-                - 192.168.1.0
-              meta:
-                up: True
-            - answer:
-                - 192.168.1.1
-              meta:
-                up: True
-          filters:
-            - filter: up
-              config: {}
-        register: return
+requirements:
+  - python >= 2.7
+  - ns1 >= 0.9.19
 
-      - name: record delete
-        local_action:
-          module: ns1_record
-          apiKey: "{{ key }}"
-          name: www
-          zone: "{{ test_zone }}"
-          state: absent
-          type: A
-          answers: []
-        register: return
+seealso:
+  - name: Documentation for NS1 API
+    description: Complete reference for the NS1 API.
+    link: https://ns1.com/api/
+
+author:
+  - 'Matthew Burtless (@mburtless)'
 '''
 
+EXAMPLES = '''
+- name: Ensure an A record with two answers, metadata and filter chain
+  ns1_record:
+    apiKey: qACMD09OJXBxT7XOuRs8
+    name: www
+    zone: test.com
+    state: present
+    type: A
+    answers:
+        - answer:
+            - 192.168.1.0
+          meta:
+            up: True
+        - answer:
+            - 192.168.1.1
+          meta:
+            up: True
+    filters:
+        - filter: up
+          config: {}
+
+- name: Ensure an A record, appending new answer to existing
+  ns1_record:
+    apiKey: qACMD09OJXBxT7XOuRs8
+    name: www
+    zone: test.com
+    record_mode: append
+    state: present
+    type: A
+    answers:
+        - answer:
+            - 192.168.1.3
+          meta:
+            up: True
+
+- name: Delete an A record
+  ns1_record:
+    apiKey: qACMD09OJXBxT7XOuRs8
+    name: www
+    zone: test.com
+    state: absent
+    type: A
+    answers: []
+
+- name: Ensure an MX record at apex of zone with a single answer
+  ns1_record:
+    apiKey: qACMD09OJXBxT7XOuRs8
+    name: test.com
+    zone: test.com
+    state: present
+    type: MX
+    answers:
+      - answer:
+          - 5
+          - mail1.example.com
+'''
+
+RETURN = '''
+'''
+
+import copy
+
+HAS_NS1 = True
 
 try:
     from ns1 import NS1, Config
     from ns1.rest.errors import ResourceException
-    HAS_NS1 = True
 except ImportError:
     HAS_NS1 = False
 
-CREATE_STATES = ['present', 'active']
-DELETE_STATES = ['absent', 'deleted']
 
-STATES = CREATE_STATES + DELETE_STATES
+NS1_COMMON_ARGS = dict(apiKey=dict(required=True, no_log=True))
 
-RECORD_KEYS = [
-    'use_client_subnet',
-    'answers',
-    'meta',
-    'link',
-    'filters',
-    'ttl',
-    'regions'
-]
 
-RECORD_KEYS_WITHOUT_ANSWERS = [
-    'use_client_subnet',
-    'meta',
-    'link',
-    'filters',
-    'ttl',
-    'regions'
-]
+class NS1ModuleBase(object):
+    def __init__(self, derived_arg_spec, supports_check_mode=False):
+        merged_arg_spec = dict()
+        merged_arg_spec.update(NS1_COMMON_ARGS)
+        if derived_arg_spec:
+            merged_arg_spec.update(derived_arg_spec)
 
-RECORD_KEYS = RECORD_KEYS_WITHOUT_ANSWERS + ['answers']
+        self.module = AnsibleModule(
+            argument_spec=merged_arg_spec, supports_check_mode=supports_check_mode
+        )
 
-TYPES = [
+        if not HAS_NS1:
+            self.module.fail_json(msg=missing_required_lib("ns1-python"))
+        self._build_ns1()
+
+    def _build_ns1(self):
+        self.config = Config()
+        self.config.createFromAPIKey(self.module.params["apiKey"])
+        self.config['transport'] = 'basic'
+        self.ns1 = NS1(config=self.config)
+
+    def errback_generator(self):
+        def errback(args):
+            self.module.fail_json(msg="%s - %s" % (args[0], args[1]))
+
+        return errback
+
+RECORD_KEYS_MAP = dict(
+    use_client_subnet=dict(appendable=False),
+    answers=dict(appendable=True),
+    meta=dict(appendable=False),
+    link=dict(appendable=False),
+    filters=dict(appendable=True),
+    ttl=dict(appendable=False),
+    regions=dict(appendable=False),
+)
+
+RECORD_TYPES = [
     'A',
     'AAAA',
     'ALIAS',
@@ -204,186 +285,204 @@ TYPES = [
     'RP',
     'SPF',
     'SRV',
-    'TXT'
+    'TXT',
 ]
 
-def errback_generator(module):
-    def errback(args):
-        module.fail_json(
-            msg="%s - %s" % (args[0], args[1])
+
+class NS1Record(NS1ModuleBase):
+    def __init__(self):
+        self.module_arg_spec = dict(
+            name=dict(required=True, type='str'),
+            zone=dict(required=True, type='str'),
+            answers=dict(
+                required=True,
+                type='list',
+                elements='dict',
+                options=dict(
+                    answer=dict(type='list', default=None),
+                    meta=dict(type='dict', default=None),
+                ),
+            ),
+            ignore_missing_zone=dict(required=False, type='bool', default=False),
+            type=dict(required=True, type='str', choices=RECORD_TYPES),
+            use_client_subnet=dict(required=False, type='bool', default=None),
+            meta=dict(required=False, type='dict', default=None),
+            link=dict(required=False, type='str', default=None),
+            filters=dict(
+                required=False,
+                type='list',
+                elements='dict',
+                default=None,
+                options=dict(
+                    filter=dict(type='str', default=None),
+                    config=dict(type='dict', default=None),
+                ),
+            ),
+            ttl=dict(required=False, type='int', default=3600),
+            regions=dict(required=False, type='dict', default=None),
+            state=dict(
+                required=False,
+                type='str',
+                default='present',
+                choices=['present', 'absent'],
+            ),
+            record_mode=dict(
+                required=False, type='str', default='purge', choices=['append', 'purge']
+            ),
         )
-    return errback
 
-def api_params(module):
-    toReturn = {}
-    for i in RECORD_KEYS_WITHOUT_ANSWERS:
-        if module.params.get(i) is not None:
-            toReturn[i] = module.params.get(i)
-    return toReturn
+        NS1ModuleBase.__init__(self, self.module_arg_spec, supports_check_mode=True)
+        self.exec_module()
 
-def clean(d):
-    if isinstance(d, dict):
-        for key,val in d.items():
-            if isinstance(val, dict) or isinstance(val, list):
-                val = clean(val)
-            if key == 'id':
-                del d[key]
-    if isinstance(d, list):
-        for i in d:
-            if isinstance(i, dict) or isinstance(i, list):
-                i = clean(i)
-    return d
-
-
-def get_zone(ns1, module):
-    to_return = None
-    try:
-        to_return = ns1.loadZone(module.params.get('zone'))
-    except ResourceException as re:
-        if re.response.code == 404:
-            if ( module.params.get('ignore_missing_zone') and
-                module.params.get('state') in DELETE_STATES):
-                # zone not found but we are in the delete state
-                # and the user doesn't care that the zone doesn't exist
-                # nothing to do and no change
-                module.exit_json(changed=False)
+    def filter_empty_subparams(self, param_name):
+        param = self.module.params.get(param_name)
+        filtered = []
+        if isinstance(param, list):
+            for subparam in param:
+                if isinstance(subparam, dict):
+                    filtered.append(
+                        dict(
+                            (key, value)
+                            for key, value in subparam.items()
+                            if value is not None
+                        )
+                    )
         else:
-            # generic error or user cares about missing zone
-            module.fail_json(
-                msg="error code %s - %s " % ( re.response.code, re.message )
-            )
+            filtered = param
+        return filtered
 
-    return to_return
-
-def get_record(zone, module):
-    to_return = None
-    try:
-        to_return = zone.loadRecord(
-            module.params.get('name'),
-            module.params.get('type').upper()
+    def api_params(self):
+        params = dict(
+            (key, self.module.params.get(key))
+            for key, value in RECORD_KEYS_MAP.items()
+            if key != "answers" and self.module.params.get(key) is not None
         )
-    except ResourceException as re:
-        if re.response.code != 404:
-            module.fail_json(
-                msg="error code %s - %s " % ( re.response.code, re.message )
-            )
-            to_return = None
-    return to_return
+        return params
 
-def update(zone, record, module):
-    cleaned_data = clean(record.data)
-    changed = False
-    args = {}
-    for i in RECORD_KEYS:
-        if (
-            module.params.get(i) and
-                (
-                    not cleaned_data or
-                    i not in cleaned_data or
-                    module.params.get(i) != cleaned_data[i]
+    def remove_id(self, d):
+        if isinstance(d, dict):
+            if 'id' in d:
+                del d['id']
+            for key, val in d.items():
+                if isinstance(val, (dict, list)):
+                    self.remove_id(val)
+        if isinstance(d, list):
+            for i in d:
+                if isinstance(i, (dict, list)):
+                    self.remove_id(i)
+        return d
+
+    def get_zone(self):
+        to_return = None
+        try:
+            to_return = self.ns1.loadZone(self.module.params.get('zone'))
+        except ResourceException as re:
+            if re.response.code == 404:
+                if (
+                    self.module.params.get('ignore_missing_zone')
+                    and self.module.params.get('state') == "absent"
+                ):
+                    # zone not found but we are in the absent state
+                    # and the user doesn't care that the zone doesn't exist
+                    # nothing to do and no change
+                    self.module.exit_json(changed=False)
+            else:
+                # generic error or user cares about missing zone
+                self.module.fail_json(
+                    msg="error code %s - %s " % (re.response.code, re.message)
                 )
-            ):
-            changed = True
-            args[i] = module.params.get(i)
 
-    if module.check_mode:
-        # check mode short circuit before update
-        module.exit_json(changed=changed)
+        return to_return
 
-    if changed:
-        # update only if changed
-        record = record.update(errback=errback_generator(module),**args)
+    def get_record(self, zone):
+        to_return = None
+        try:
+            to_return = zone.loadRecord(
+                self.module.params.get('name'), self.module.params.get('type').upper()
+            )
+        except ResourceException as re:
+            if re.response.code != 404:
+                self.module.fail_json(
+                    msg="error code %s - %s " % (re.response.code, re.message)
+                )
+                to_return = None
+        return to_return
 
-    module.exit_json(changed=changed, id=record['id'], data=record.data)
+    def update(self, zone, record):
+        # Clean copy of record to preserve IDs for response if no update required
+        record_data = self.remove_id(copy.deepcopy(record.data))
+        changed = False
+        args = {}
+
+        for key in RECORD_KEYS_MAP:
+            input_data = self.filter_empty_subparams(key)
+
+            if input_data is not None:
+                if (
+                    RECORD_KEYS_MAP[key]['appendable']
+                    and self.module.params.get('record_mode') == 'append'
+                ):
+                    # Create union of input and existing record data, preserving existing order
+                    input_data = record_data[key] + [
+                        input_obj
+                        for input_obj in input_data
+                        if input_obj not in record_data[key]
+                    ]
+
+                if input_data != record_data[key]:
+                    changed = True
+                    args[key] = input_data
+
+        if self.module.check_mode:
+            # check mode short circuit before update
+            self.module.exit_json(changed=changed)
+
+        if changed:
+            # update only if some changed data
+            record = record.update(errback=self.errback_generator(), **args)
+
+        self.module.exit_json(changed=changed, id=record['id'], data=record.data)
+
+    def exec_module(self):
+        state = self.module.params.get('state')
+        zone = self.get_zone()
+        record = self.get_record(zone)
+
+        # record found
+        if record:
+            if state == "absent":
+                if self.module.check_mode:
+                    # short circut in check mode
+                    self.module.exit_json(changed=True)
+
+                record.delete(errback=self.errback_generator())
+                self.module.exit_json(changed=True)
+            else:
+                self.update(zone, record)
+        else:
+            if state == "absent":
+                self.module.exit_json(changed=False)
+            else:
+                if self.module.check_mode:
+                    # short circuit in check mode
+                    self.module.exit_json(changed=True)
+
+                method_to_call = getattr(
+                    zone, 'add_%s' % (self.module.params.get('type').upper())
+                )
+
+                record = method_to_call(
+                    self.module.params.get('name'),
+                    self.filter_empty_subparams('answers'),
+                    errback=self.errback_generator(),
+                    **self.api_params()
+                )
+                self.module.exit_json(changed=True, id=record['id'], data=record.data)
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec           = dict(
-            apiKey              = dict(required=True, no_log=True),
-            name                = dict(required=True),
-            zone                = dict(required=True),
-            answers             = dict(required=True, type='list'),
-            ignore_missing_zone = dict(required=False, default=False),
-            type                = dict(
-                                    required=True,
-                                    choices=(
-                                        list(map(lambda x:x.lower(),TYPES)) + TYPES)
-                                    ),
-            use_client_subnet   = dict(
-                                    required=False,
-                                    default=None,
-                                    type='bool'
-                                ),
-            meta                = dict(required=False, default=None),
-            link                = dict(required=False, default=None),
-            filters             = dict(required=False, type='list', default=None),
-            ttl                 = dict(
-                                    required=False,
-                                    type='int',
-                                    default=3600
-                                ),
-            regions             = dict(required=False, type='dict', default=None),
-            state               = dict(
-                                    required=False,
-                                    default='present',
-                                    choices=STATES
-                                ),
-            ),
-        supports_check_mode=True
-    )
+    NS1Record()
 
-    if not HAS_NS1:
-        module.fail_json(msg='the ns1 client lib is required for this module')
-
-    config = Config()
-    config.createFromAPIKey(module.params.get('apiKey'))
-    config['transport'] = 'basic'
-    ns1 = NS1(config=config)
-
-    zone = get_zone(ns1, module)
-
-    record = get_record(zone, module)
-
-    # record found
-    if record:
-        if module.params.get('state') in DELETE_STATES:
-            if module.check_mode:
-                # short circut in check mode
-                module.exit_json(changed=True)
-
-            # we want it deleted
-            record.delete(errback=errback_generator(module))
-            module.exit_json(changed=True)
-        else:
-            update(zone, record, module)
-    else:
-        if module.params.get('state') in DELETE_STATES:
-            module.exit_json(changed=False)
-        else:
-            if module.check_mode:
-                # short circuit in check mode
-                module.exit_json(changed=True)
-
-            methodToCall = getattr(
-                zone,
-                'add_%s' % (module.params.get('type').upper())
-            )
-
-            record = methodToCall(
-                module.params.get('name'),
-                module.params.get('answers'),
-                errback=errback_generator(module),
-                **api_params(module)
-            )
-            module.exit_json(
-                changed=True,
-                id=record['id'],
-                data=record.data
-            )
-
-
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/library/ns1_record.py
+++ b/library/ns1_record.py
@@ -30,6 +30,7 @@ options:
     description:
       - Whether the record should be present or not.  Use C(present) to create
         or update and C(absent) to delete.
+    type: str
     default: present
     choices:
       - absent
@@ -38,16 +39,19 @@ options:
     description:
       - The subdomain of the record. For apex records, this should match the
         value of I(zone).
+    type: str
     required: true
   zone:
     description:
       - Name of the existing DNS zone in which to manage the record.
+    type: str
     required: true
   answers:
     description:
       - An array of answers for this record (order matters). This can take
         many forms depending on record type and desired effect. See
         U(https://ns1.com/api) for more details.
+    type: list
     required: true
     suboptions:
       answer:
@@ -67,12 +71,14 @@ options:
         flag to C(True). This module will then count any record without a valid
         zone as absent.  This is useful for ensuring a record is absent,
         regardless of the status of its zone.
+    type: bool
     required: false
     default: false
   record_mode:
     description:
       - Whether existing I(answers) or I(filters) values unspecified in the module
         should be purged
+    type: str
     default: purge
     choices:
       - append
@@ -80,6 +86,7 @@ options:
   type:
     description:
       - The type of the record to create, modify or delete.
+    type: str
     required: true
     choices:
       - A
@@ -100,24 +107,29 @@ options:
   use_client_subnet:
     description:
       - Whether record should be EDNS-Client-Subnet enabled
+    type: bool
     required: false
   meta:
     description:
       - Record level metadata.
+    type: dict
     required: false
   link:
     description:
       - The target of a linked record.
+    type: str
     required: false
   filters:
     description:
       - An array of filters for the record, for use in configuring dynamic
         records (order matters)
+    type: list
     required: false
     suboptions:
       filter:
         description:
           - The type of filter.
+        type: str
         required: false
       config:
         description:
@@ -127,11 +139,13 @@ options:
   ttl:
     description:
       - The TTL of the record.
+    type: int
     required: false
     default: 3600
   regions:
     description:
       - The regions object for the record set.
+    type: dict
     required: false
 
 extends_documentation_fragment:

--- a/library/ns1_record.py
+++ b/library/ns1_record.py
@@ -4,14 +4,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from ansible.module_utils.basic import AnsibleModule
-
-try: 
-    from ansible.module_utils.basic import missing_required_lib 
-except Exception: 
-    def missing_required_lib(msg, reason=None, url=None):
-        return msg
-
 
 __metaclass__ = type
 
@@ -141,19 +133,9 @@ options:
     description:
       - The regions object for the record set.
     required: false
-  apiKey:
-    description:
-      - Unique client api key that can be created via the NS1 portal.
-    required: true
 
-requirements:
-  - python >= 2.7
-  - ns1 >= 0.9.19
-
-seealso:
-  - name: Documentation for NS1 API
-    description: Complete reference for the NS1 API.
-    link: https://ns1.com/api/
+extends_documentation_fragment:
+  - ns1
 
 author:
   - 'Matthew Burtless (@mburtless)'
@@ -221,44 +203,14 @@ RETURN = '''
 
 import copy
 
-HAS_NS1 = True
+from ansible.module_utils.ns1 import NS1ModuleBase, HAS_NS1
 
 try:
     from ns1 import NS1, Config
     from ns1.rest.errors import ResourceException
 except ImportError:
-    HAS_NS1 = False
-
-
-NS1_COMMON_ARGS = dict(apiKey=dict(required=True, no_log=True))
-
-
-class NS1ModuleBase(object):
-    def __init__(self, derived_arg_spec, supports_check_mode=False):
-        merged_arg_spec = dict()
-        merged_arg_spec.update(NS1_COMMON_ARGS)
-        if derived_arg_spec:
-            merged_arg_spec.update(derived_arg_spec)
-
-        self.module = AnsibleModule(
-            argument_spec=merged_arg_spec, supports_check_mode=supports_check_mode
-        )
-
-        if not HAS_NS1:
-            self.module.fail_json(msg=missing_required_lib("ns1-python"))
-        self._build_ns1()
-
-    def _build_ns1(self):
-        self.config = Config()
-        self.config.createFromAPIKey(self.module.params["apiKey"])
-        self.config['transport'] = 'basic'
-        self.ns1 = NS1(config=self.config)
-
-    def errback_generator(self):
-        def errback(args):
-            self.module.fail_json(msg="%s - %s" % (args[0], args[1]))
-
-        return errback
+    # This is handled in NS1 module_utils
+    pass
 
 RECORD_KEYS_MAP = dict(
     use_client_subnet=dict(appendable=False),

--- a/module_utils/ns1.py
+++ b/module_utils/ns1.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Matthew Burtless <mburtless@ns1.com>
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+# Make coding more python3-ish
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+
+try: 
+    from ansible.module_utils.basic import missing_required_lib 
+except Exception: 
+    def missing_required_lib(msg, reason=None, url=None): 
+        return msg
+
+HAS_NS1 = True
+
+try:
+    from ns1 import NS1, Config
+    from ns1.rest.errors import ResourceException
+except ImportError:
+    HAS_NS1 = False
+
+
+NS1_COMMON_ARGS = dict(apiKey=dict(required=True, no_log=True))
+
+
+class NS1ModuleBase(object):
+    def __init__(self, derived_arg_spec, supports_check_mode=False):
+        merged_arg_spec = dict()
+        merged_arg_spec.update(NS1_COMMON_ARGS)
+        if derived_arg_spec:
+            merged_arg_spec.update(derived_arg_spec)
+
+        self.module = AnsibleModule(
+            argument_spec=merged_arg_spec, supports_check_mode=supports_check_mode
+        )
+
+        if not HAS_NS1:
+            self.module.fail_json(msg=missing_required_lib("ns1-python"))
+        self._build_ns1()
+
+    def _build_ns1(self):
+        self.config = Config()
+        self.config.createFromAPIKey(self.module.params["apiKey"])
+        self.config['transport'] = 'basic'
+        self.ns1 = NS1(config=self.config)
+
+    def errback_generator(self):
+        def errback(args):
+            self.module.fail_json(msg="%s - %s" % (args[0], args[1]))
+
+        return errback

--- a/module_utils/ns1.py
+++ b/module_utils/ns1.py
@@ -29,14 +29,17 @@ NS1_COMMON_ARGS = dict(apiKey=dict(required=True, no_log=True))
 
 
 class NS1ModuleBase(object):
-    def __init__(self, derived_arg_spec, supports_check_mode=False):
+    def __init__(self, derived_arg_spec, supports_check_mode=False,
+                 mutually_exclusive=None):
         merged_arg_spec = dict()
         merged_arg_spec.update(NS1_COMMON_ARGS)
         if derived_arg_spec:
             merged_arg_spec.update(derived_arg_spec)
 
         self.module = AnsibleModule(
-            argument_spec=merged_arg_spec, supports_check_mode=supports_check_mode
+            argument_spec=merged_arg_spec,
+            supports_check_mode=supports_check_mode,
+            mutually_exclusive=mutually_exclusive
         )
 
         if not HAS_NS1:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,5 +1,0 @@
-# Testing
-Tests in this directory can be run via ansible directly:
-```
-ansible-playbook -i local, ns1_record.yml --extra-vars ns1_token=$NS1_APIKEY --extra-vars debug=yes -M ../library
-```

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,5 @@
+# Testing
+Tests in this directory can be run via ansible directly:
+```
+ansible-playbook -i local, ns1_record.yml --extra-vars ns1_token=$NS1_APIKEY --extra-vars debug=yes -M ../library
+```

--- a/tests/ns1_record.yaml
+++ b/tests/ns1_record.yaml
@@ -1,0 +1,239 @@
+---
+  - hosts: localhost
+    vars:
+      test_zone: nsonetestzone.com
+      test_record: www
+      # debug: on
+    tasks:
+      - name: setup
+        local_action:
+          module: ns1_record
+          apiKey: "{{ ns1_token }}"
+          name: "{{ test_record }}"
+          zone: "{{ test_zone }}"
+          state: absent
+          type: A
+          answers: []
+        register: record_setup
+
+      - name: Verify setup
+        assert:
+          that:
+            - record_setup is success
+
+      - name: Test record creation
+        local_action:
+          module: ns1_record
+          apiKey: "{{ ns1_token }}"
+          name: "{{ test_record }}"
+          zone: "{{ test_zone }}"
+          state: present
+          type: A
+          answers:
+            - answer:
+                - 192.168.1.0
+              meta:
+                up: True
+          filters:
+            - filter: up
+              config: {}
+        register: a_record_create
+
+      - name: Verify record creation
+        assert:
+          that:
+            - a_record_create is changed
+            - a_record_create.data.answers[0].answer[0] == "192.168.1.0"
+
+      - name: Test answer append
+        local_action:
+          module: ns1_record
+          apiKey: "{{ ns1_token }}"
+          name: "{{ test_record }}"
+          zone: "{{ test_zone }}"
+          state: present
+          record_mode: append
+          type: A
+          answers:
+            - answer:
+                - 192.168.1.1
+              meta:
+                up: True
+          filters:
+            - filter: up
+              config: {}
+        register: a_answer_append
+
+      - name: Verify answer append
+        assert:
+          that:
+            - a_answer_append is changed
+            - a_answer_append.data.answers[0].answer[0] == "192.168.1.0"
+            - a_answer_append.data.answers[1].answer[0] == "192.168.1.1"
+            - a_answer_append.data.answers | length == 2
+
+      - name: Test record no change
+        local_action:
+          module: ns1_record
+          apiKey: "{{ ns1_token }}"
+          name: "{{ test_record }}"
+          zone: "{{ test_zone }}"
+          state: present
+          record_mode: append
+          type: A
+          answers:
+            - answer:
+                - 192.168.1.1
+              meta:
+                up: True
+          filters:
+            - filter: up
+              config: {}
+        register: a_record_no_change
+
+      - name: Verify record no change
+        assert:
+          that:
+            - a_record_no_change is not changed
+            - a_record_no_change.data.answers[1].answer[0] == "192.168.1.1"
+            - a_record_no_change.data.answers | length == 2
+
+      - name: Test answer update with purge
+        local_action:
+          module: ns1_record
+          apiKey: "{{ ns1_token }}"
+          name: "{{ test_record }}"
+          zone: "{{ test_zone }}"
+          state: present
+          type: A
+          answers:
+            - answer:
+                - 192.168.2.1
+              meta:
+                up: True
+          filters:
+            - filter: up
+              config: {}
+        register: a_answer_update_purge
+
+      - name: Verify answer update with purge
+        assert:
+          that:
+            - a_answer_update_purge is changed
+            - a_answer_update_purge.data.answers[0].answer[0] == "192.168.2.1"
+            - a_answer_update_purge.data.answers | length == 1
+
+      - name: Test filter append
+        ns1_record:
+          apiKey: "{{ ns1_token }}"
+          name: "{{ test_record }}"
+          zone: "{{ test_zone }}"
+          state: present
+          record_mode: append
+          type: A
+          answers: []
+          filters:
+            - filter: geotarget_regional
+              config: {}
+        register: a_filter_append
+
+      - name: Verify filter append
+        assert:
+          that:
+            - a_filter_append is changed
+            - a_filter_append.data.answers[0].answer[0] == "192.168.2.1"
+            - a_filter_append.data.filters[0].filter == "up"
+            - a_filter_append.data.filters[1].filter == "geotarget_regional"
+
+      - name: Test filter purge
+        local_action:
+          module: ns1_record
+          apiKey: "{{ ns1_token }}"
+          name: "{{ test_record }}"
+          zone: "{{ test_zone }}"
+          record_mode: purge
+          state: present
+          type: A
+          answers: []
+          filters: []
+        register: a_filter_purge
+
+      - name: Verify filter purge
+        assert:
+          that:
+            - a_filter_purge is changed
+            - a_filter_purge.data.filters | length == 0
+
+      - name: Test meta update
+        local_action:
+          module: ns1_record
+          apiKey: "{{ ns1_token }}"
+          name: "{{ test_record }}"
+          zone: "{{ test_zone }}"
+          record_mode: purge
+          state: present
+          type: A
+          answers:
+            - answer:
+                - 192.168.2.1
+              meta:
+                up: False
+        register: a_meta_update
+
+      - name: Verify meta update
+        assert:
+          that:
+            - a_meta_update is changed
+            - a_meta_update.data.answers[0].answer[0] == "192.168.2.1"
+            - a_meta_update.data.answers | length == 1
+
+      - name: Test answer purge
+        local_action:
+          module: ns1_record
+          apiKey: "{{ ns1_token }}"
+          name: "{{ test_record }}"
+          zone: "{{ test_zone }}"
+          record_mode: purge
+          state: present
+          type: A
+          answers: []
+        register: a_answer_purge
+
+      - name: Verify answer purge
+        assert:
+          that:
+            - a_answer_purge is changed
+            - a_answer_purge.data.answers | length == 0
+
+      - name: Test record deletion
+        local_action:
+          module: ns1_record
+          apiKey: "{{ ns1_token }}"
+          name: "{{ test_record }}"
+          zone: "{{ test_zone }}"
+          state: absent
+          type: A
+          answers: []
+        register: a_record_delete
+
+      - name: Verify record deletetion
+        assert:
+          that:
+            - a_record_delete is changed
+
+      - name: Test record deletion without existing zone
+        local_action:
+          module: ns1_record
+          apiKey: "{{ ns1_token }}"
+          name: "{{ test_record }}"
+          zone: "missing-{{ test_zone }}"
+          state: absent
+          type: A
+          answers: []
+          ignore_missing_zone: True
+        register: a_record_missing_zone_delete
+
+      - name: Verify record deletetion without existing zone
+        assert:
+          that:
+            - a_record_missing_zone_delete is not changed


### PR DESCRIPTION
Merges pieces of this module submitted to ansible-core in https://github.com/ansible/ansible/pull/53964 (`module_utils`, `doc_fragments`, etc) into a single module, for preview until this is available directly via ansible_core.

Also provides functional acceptance tests.