### PR TITLE
ns1_record: Fix support for boolean parameters

### DIFF
--- a/library/ns1_record
+++ b/library/ns1_record
@@ -276,11 +276,11 @@ def update(zone, record, module):
     args = {}
     for i in RECORD_KEYS:
         if (
-            module.params.get(i) and
+            i in module.params and
                 (
                     not cleaned_data or
                     i not in cleaned_data or
-                    module.params.get(i) != cleaned_data[i]
+                    module.params[i] != cleaned_data[i]
                 )
             ):
             changed = True


### PR DESCRIPTION
For example, 'use_client_subnet' is silently ignored because of this.

---

Not sure if you care about master branch, but… :)