### PR TITLE
[WIP] Refactor Support For Secondary Zones

### DIFF
--- a/tests/ns1_zone.yaml
+++ b/tests/ns1_zone.yaml
@@ -1,114 +1,153 @@
 ---
-  - hosts: localhost
+- hosts: localhost
 
-    tasks:
-      - name: setup
-        local_action:
-          module: ns1_zone
-          apiKey: "{{ ns1_token }}"
-          name: "{{ test_zone }}"
-          state: absent
-        register: zone_setup
+  tasks:
+    - name: setup
+      local_action:
+        module: ns1_zone
+        apiKey: "{{ ns1_token }}"
+        name: "{{ test_zone }}"
+        state: absent
+      register: zone_setup
 
-      - name: Verify setup
-        assert:
-          that:
-            - zone_setup is success
-      
-      - name: Test zone creation
-        local_action:
-          module: ns1_zone
-          apiKey: "{{ ns1_token }}"
-          name: "{{ test_zone }}"
-          refresh: 200
-          state: present
-        register: zone_create
+    - name: Verify setup
+      assert:
+        that:
+          - zone_setup is success
 
-      - name: Verify zone creation
-        assert:
-          that:
-            - zone_create is changed
-            - zone_create.data.zone == "{{ test_zone }}"
-            - zone_create.data.refresh == 200
+    - name: Test zone creation
+      local_action:
+        module: ns1_zone
+        apiKey: "{{ ns1_token }}"
+        name: "{{ test_zone }}"
+        refresh: 200
+        state: present
+      register: zone_create
 
-      - name: Test zone update
-        local_action:
-          module: ns1_zone
-          apiKey: "{{ ns1_token }}"
-          name: "{{ test_zone }}"
-          refresh: 400
-          ttl: 400
-          state: present
-        register: zone_update
+    - name: Verify zone creation
+      assert:
+        that:
+          - zone_create is changed
+          - zone_create.data.zone == "{{ test_zone }}"
+          - zone_create.data.refresh == 200
 
-      - name: Verify zone update
-        assert:
-          that:
-            - zone_update is changed
-            - zone_update.data.refresh == 400
-            - zone_update.data.ttl == 400
+    - name: Test zone update
+      local_action:
+        module: ns1_zone
+        apiKey: "{{ ns1_token }}"
+        name: "{{ test_zone }}"
+        refresh: 400
+        ttl: 400
+        state: present
+      register: zone_update
 
-      - name: Test enabling dnssec
-        local_action:
-          module: ns1_zone
-          apiKey: "{{ ns1_token }}"
-          name: "{{ test_zone }}"
-          dnssec: True
-          state: present
-        register: zone_enable_dnssec
+    - name: Verify zone update
+      assert:
+        that:
+          - zone_update is changed
+          - zone_update.data.refresh == 400
+          - zone_update.data.ttl == 400
 
-      - name: Verify dnssec enabled
-        assert:
-          that:
-            - zone_enable_dnssec is changed
-            - zone_enable_dnssec.data.dnssec == True
+    - name: Test enabling dnssec
+      local_action:
+        module: ns1_zone
+        apiKey: "{{ ns1_token }}"
+        name: "{{ test_zone }}"
+        dnssec: True
+        state: present
+      register: zone_enable_dnssec
 
-      - name: Test disabling dnssec
-        local_action:
-          module: ns1_zone
-          apiKey: "{{ ns1_token }}"
-          name: "{{ test_zone }}"
-          dnssec: False
-          state: present
-        register: zone_disable_dnssec
+    - name: Verify dnssec enabled
+      assert:
+        that:
+          - zone_enable_dnssec is changed
+          - zone_enable_dnssec.data.dnssec == True
 
-      - name: Verify dnssec disabled
-        assert:
-          that:
-            - zone_disable_dnssec is changed
-            - zone_disable_dnssec.data.dnssec == False
+    - name: Test disabling dnssec
+      local_action:
+        module: ns1_zone
+        apiKey: "{{ ns1_token }}"
+        name: "{{ test_zone }}"
+        dnssec: False
+        state: present
+      register: zone_disable_dnssec
 
-      - name: Test linked zone creation
-        local_action:
-          module: ns1_zone
-          apiKey: "{{ ns1_token }}"
-          name: "linked-{{ test_zone }}"
-          link: "{{ test_zone }}"
-          state: present
-        register: linked_zone
+    - name: Verify dnssec disabled
+      assert:
+        that:
+          - zone_disable_dnssec is changed
+          - zone_disable_dnssec.data.dnssec == False
 
-      - name: Verify linked zone creation
-        assert:
-          that:
-            - linked_zone is changed
-            - linked_zone.data.link == "{{ test_zone }}"
- 
-      - name: Delete linked zone
-        local_action:
-          module: ns1_zone
-          apiKey: "{{ ns1_token }}"
-          name: "linked-{{ test_zone }}"
-          state: absent
-      
-      - name: Test zone deletion
-        local_action:
-          module: ns1_zone
-          apiKey: "{{ ns1_token }}"
-          name: "{{ test_zone }}"
-          state: absent
-        register: zone_delete
+    - name: Test linked zone creation
+      local_action:
+        module: ns1_zone
+        apiKey: "{{ ns1_token }}"
+        name: "linked-{{ test_zone }}"
+        link: "{{ test_zone }}"
+        state: present
+      register: linked_zone
 
-      - name: Verify zone deletion
-        assert:
-          that:
-            - zone_delete is changed
+    - name: Verify linked zone creation
+      assert:
+        that:
+          - linked_zone is changed
+          - linked_zone.data.link == "{{ test_zone }}"
+
+    - name: Delete linked zone
+      local_action:
+        module: ns1_zone
+        apiKey: "{{ ns1_token }}"
+        name: "linked-{{ test_zone }}"
+        state: absent
+
+    - name: Test secondary zone creation
+      local_action:
+        module: ns1_zone
+        apiKey: "{{ ns1_token }}"
+        name: "secondary-{{ test_zone }}"
+        secondary:
+          enabled: True
+          primary_ip: 1.1.1.1
+        state: present
+      register: secondary_zone
+
+    - name: Verify secondary zone creation
+      assert:
+        that:
+          - secondary_zone is changed
+
+    - name: Test secondary zone no-op
+      local_action:
+        module: ns1_zone
+        apiKey: "{{ ns1_token }}"
+        name: "secondary-{{ test_zone }}"
+        secondary:
+          enabled: True
+          primary_ip: 1.1.1.1
+        state: present
+      register: secodary_zone_noop
+
+    - name: Verify secondary zone no-op
+      assert:
+        that:
+          - secodary_zone_noop is not changed
+
+    - name: Delete secondary zone
+      local_action:
+        module: ns1_zone
+        apiKey: "{{ ns1_token }}"
+        name: "secondary-{{ test_zone }}"
+        state: absent
+
+    - name: Test zone deletion
+      local_action:
+        module: ns1_zone
+        apiKey: "{{ ns1_token }}"
+        name: "{{ test_zone }}"
+        state: absent
+      register: zone_delete
+
+    - name: Verify zone deletion
+      assert:
+        that:
+          - zone_delete is changed


### PR DESCRIPTION
Extends option for secondary zones with defined suboptions and change detection.  Fixes #24 

TODO:
* Support for `other_ips`, `other_ports`, `tsig`
* Factor all change detection out of `update`
* Integration tests for all suboptions
* handle API error on converting primary to secondary