### PR TITLE
Add TSIG Suboption For Secondary Zones

### DIFF
--- a/tests/ns1_zone.yaml
+++ b/tests/ns1_zone.yaml
@@ -126,6 +126,7 @@
             - secondary_zone is changed
             - secondary_zone.zone.secondary.enabled == True
             - secondary_zone.zone.secondary.tsig.enabled == True
+
       - name: Disable secondary zone
         local_action:
           module: ns1_zone

--- a/tests/ns1_zone.yaml
+++ b/tests/ns1_zone.yaml
@@ -6,15 +6,19 @@
         local_action:
           module: ns1_zone
           apiKey: "{{ ns1_token }}"
-          name: "{{ test_zone }}"
+          name: "{{ item }}"
           state: absent
+        loop:
+          - "{{ test_zone }}"
+          - "linked-{{ test_zone }}"
+          - "secondary-{{ test_zone }}"
         register: zone_setup
 
       - name: Verify setup
         assert:
           that:
             - zone_setup is success
-      
+
       - name: Test zone creation
         local_action:
           module: ns1_zone
@@ -92,7 +96,7 @@
           that:
             - linked_zone is changed
             - linked_zone.zone.link == "{{ test_zone }}"
- 
+
       - name: Delete linked zone
         local_action:
           module: ns1_zone
@@ -108,6 +112,11 @@
           secondary:
             enabled: True
             primary_ip: "1.1.1.1"
+            tsig:
+              enabled: true
+              hash: "hmac-256"
+              name: "testkey"
+              key: "fookey"
           state: present
         register: secondary_zone
 
@@ -116,7 +125,7 @@
           that:
             - secondary_zone is changed
             - secondary_zone.zone.secondary.enabled == True
-
+            - secondary_zone.zone.secondary.tsig.enabled == True
       - name: Disable secondary zone
         local_action:
           module: ns1_zone

--- a/tests/unit/test_ns1_zone.py
+++ b/tests/unit/test_ns1_zone.py
@@ -49,6 +49,22 @@ def test_module_fail_when_required_args_missing():
             id="updated_dict_param",
         ),
         pytest.param(
+            {
+                "secondary": {
+                    "enabled": True,
+                    "tsig": {"enabled": True}
+                }
+            },
+            {
+                "secondary": {
+                    "enabled": True,
+                    "tsig": {"enabled": True, "name": "foo"},
+                }
+            },
+            {"secondary": {"tsig": {"name": "foo"}}},
+            id="updated_nested_dict_param",
+        ),
+        pytest.param(
             {"networks": [1, 2, 3]},
             {"networks": []},
             {"networks": []},
@@ -141,6 +157,22 @@ def test_check_mode(mock_zone_update, ns1_config, check_mode):
             {"secondary": {"enabled": True, "primary_ip": "1.1.1.1"}},
             {"secondary": {"enabled": True, "primary_ip": "1.1.1.1"}},
             id="suboption",
+        ),
+        pytest.param(
+            {
+                "name": "foo",
+                "secondary": {
+                    "enabled": True,
+                    "tsig": {"enabled": True, "name": "key_name"},
+                },
+            },
+            {
+                "secondary": {
+                    "enabled": True,
+                    "tsig": {"enabled": True, "name": "key_name"},
+                }
+            },
+            id="nested_suboption",
         ),
         pytest.param(
             {"secondary": {"enabled": True, "primary_ip": None}},


### PR DESCRIPTION
Adds support and tests for tsig suboption.

Resolves a defect where `sanitize_params()` would remove nested params named `name`, even though desired behavior is to only sanitize root `name` param.