### PR TITLE
Fix deprecated use of raumel.yaml

### DIFF
--- a/library/ns1_record.py
+++ b/library/ns1_record.py
@@ -269,7 +269,8 @@ RETURN = '''
 '''
 
 import copy  # noqa
-import ruamel.yaml as yaml
+from ruamel.yaml import YAML
+import sys
 
 try:
     from ansible.module_utils.ns1 import NS1ModuleBase
@@ -548,8 +549,10 @@ class NS1Record(NS1ModuleBase):
         :type : Bool
         """
         # convert dictionaries to yaml txt dump
-        before_yaml = yaml.safe_dump(before, default_flow_style=False)
-        after_yaml = yaml.safe_dump(after, default_flow_style=False)
+        yaml=YAML(typ='safe')
+        yaml.default_flow_style = False
+        before_yaml = yaml.dump(before, sys.stdout)
+        after_yaml = yaml.dump(after, sys.stdout)
 
         # build the final dict to pass into exit_json
         if self.module._diff:

--- a/library/ns1_record.py
+++ b/library/ns1_record.py
@@ -270,7 +270,7 @@ RETURN = '''
 
 import copy  # noqa
 from ruamel.yaml import YAML
-import sys
+from io import StringIO
 
 try:
     from ansible.module_utils.ns1 import NS1ModuleBase
@@ -551,8 +551,12 @@ class NS1Record(NS1ModuleBase):
         # convert dictionaries to yaml txt dump
         yaml=YAML(typ='safe')
         yaml.default_flow_style = False
-        before_yaml = yaml.dump(before, sys.stdout)
-        after_yaml = yaml.dump(after, sys.stdout)
+        with StringIO() as before_stream:
+            yaml.dump(before, stream=before_stream)
+            before_yaml = before_stream.getvalue()
+        with StringIO() as after_stream:
+            yaml.dump(after, stream=after_stream)
+            after_yaml = after_stream.getvalue()
 
         # build the final dict to pass into exit_json
         if self.module._diff:


### PR DESCRIPTION
Since version 0.17.0 in 2021, `ruamel.yaml` has warned against the use of its `safe_dump()` function. Recent versions now throw an exception when you try to use it, rendering the NS1 Ansible module unusable. This PR updates the use of `ruamel.yaml` to use the supported method of dumping YAML.